### PR TITLE
feat: Add support for removing commands between two dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,70 +37,72 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -151,15 +153,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -175,12 +177,12 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -198,6 +200,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "getrandom"
@@ -223,19 +231,20 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -257,9 +266,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -279,15 +288,15 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-traits"
@@ -305,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,18 +331,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -363,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustix"
@@ -377,8 +392,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "shlex"
@@ -394,9 +415,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -413,7 +434,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -445,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "utf8parse"
@@ -475,20 +496,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -500,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -510,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,17 +546,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -543,12 +595,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -557,14 +645,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -574,10 +679,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -586,10 +703,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -598,10 +727,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -610,10 +751,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zsh-history-cleaner"
 version = "0.2.0-unreleased"
 edition = "2024"
-description = "Clean your history by removing duplicate commands, commands matching regex, etc..."
+description = "Clean your commands history by removing duplicate commands, commands between dates, etc..."
 repository = "https://github.com/haidaraM/zsh-history-cleaner"
 readme = "README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A command line tool to clean your .zsh history by:
 
 - Removing duplicate commands: the first command is kept among the duplicates.
-- Removing commands from a specific time range (TODO)
+- Removing commands from specific time ranges.
 - Removing commands matching some patterns (TODO)
 
 > [!WARNING]  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ zhc --help
 ## Usage
 
 ```
-Clean your history by removing duplicate commands, commands matching regex, etc...
+Clean your history by removing duplicate commands, command
 
 By default, all the duplicate commands are removed.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ zhc --help
 ## Usage
 
 ```
-Clean your history by removing duplicate commands, command
+Clean your commands history by removing duplicate commands, commands between dates, etc...
 
 By default, all the duplicate commands are removed.
 
@@ -47,6 +47,9 @@ Options:
 
   -k, --keep-duplicates
           Should we keep duplicate commands in the history file?
+
+  -r, --remove-between <START_DATE> <END_DATE>
+          Remove commands between the provided two dates (included): YYYY-MM-DD YYYY-MM-DD. The first date must be before or equal to the second date. Example: --remove-between 2023-01-01 2023-06-30
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,6 @@
 use crate::errors;
-use chrono::Local;
 use chrono::DateTime;
+use chrono::Local;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
@@ -46,7 +46,7 @@ impl HistoryEntry {
     }
 
     /// Converts the UNIX timestamp to a `DateTime<Local>`, returning None for invalid timestamps.
-    pub fn timestamp_as_local_date_time(&self) -> Option<DateTime<Local>> {
+    pub fn timestamp_as_date_time(&self) -> Option<DateTime<Local>> {
         DateTime::from_timestamp(self.timestamp as i64, 0).map(|dt| dt.with_timezone(&Local))
     }
 
@@ -65,7 +65,7 @@ impl Display for HistoryEntry {
         write!(
             f,
             "Command executed at '{}' for '{}s': {}",
-            self.timestamp_as_local_date_time()
+            self.timestamp_as_date_time()
                 .map_or_else(|| self.timestamp.to_string(), |dt| dt.to_string()),
             self.duration.as_secs(),
             self.command,
@@ -257,23 +257,23 @@ world'\"#;
     }
 
     #[test]
-    fn test_timestamp_as_local_date_time() {
+    fn test_timestamp_as_date_time() {
         let entry = HistoryEntry::try_from(": 1759099958:0;ls").unwrap();
         assert_eq!(
-            entry.timestamp_as_local_date_time().unwrap().timestamp() as u64,
+            entry.timestamp_as_date_time().unwrap().timestamp() as u64,
             1759099958
         );
 
         assert_eq!(
             entry.timestamp,
-            entry.timestamp_as_local_date_time().unwrap().timestamp() as u64
+            entry.timestamp_as_date_time().unwrap().timestamp() as u64
         );
     }
 
     #[test]
-    fn test_timestamp_as_local_date_time_edge_cases() {
+    fn test_timestamp_as_date_time_edge_cases() {
         // Test timestamp 0 (Unix epoch)
         let entry_zero = HistoryEntry::try_from(": 0000000000:0;ls").unwrap();
-        assert!(entry_zero.timestamp_as_local_date_time().is_some());
+        assert!(entry_zero.timestamp_as_date_time().is_some());
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,6 @@
 use crate::errors;
-use chrono::DateTime;
 use chrono::Local;
+use chrono::DateTime;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
@@ -64,11 +64,11 @@ impl Display for HistoryEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Command: '{}', Executed at: {}, Duration: {}s",
-            self.command,
+            "Command executed at '{}' for '{}s': {}",
             self.timestamp_as_local_date_time()
                 .map_or_else(|| self.timestamp.to_string(), |dt| dt.to_string()),
-            self.duration.as_secs()
+            self.duration.as_secs(),
+            self.command,
         )
     }
 }
@@ -254,16 +254,6 @@ world'\"#;
 
         let entry_3 = HistoryEntry::try_from(": 1731084669:1;terraform apply".to_string()).unwrap();
         assert_ne!(entry_1, entry_3);
-    }
-
-    // Test the Display implementation for HistoryEntry
-    #[test]
-    fn test_display_history() {
-        let history = HistoryEntry::try_from(": 1731884069:10;cd ~").unwrap();
-        assert_eq!(
-            "Command: 'cd ~', Executed at: 2024-11-17 23:54:29 +01:00, Duration: 10s",
-            format!("{}", history)
-        );
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -130,7 +130,7 @@ impl History {
         let percent_of_duplicate =
             (before_count - self.entries.len() as f64) / before_count * 100.0;
         println!(
-            "{} entries after removing duplicates ({percent_of_duplicate:.0}% of duplicates).",
+            "{} entries after removing duplicates ({percent_of_duplicate:.2}% of duplicates).",
             self.entries.len(),
         );
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -108,7 +108,7 @@ impl History {
 
     /// Remove the duplicate commands from the history.
     /// This function retains the last occurrence of a command when duplicates are found.
-    pub fn remove_duplicates(&mut self) {
+    pub fn remove_duplicates(&mut self) -> usize {
         let before_count = self.entries.len();
         let mut command_to_last_index: HashMap<&str, usize> = HashMap::new();
 
@@ -129,6 +129,8 @@ impl History {
 
         let removed_count = before_count - self.entries.len();
         println!("{} duplicate commands removed.", removed_count);
+
+        removed_count
     }
 
     pub fn remove_between_dates(&mut self, start: &NaiveDate, end: &NaiveDate) -> usize {

--- a/src/history.rs
+++ b/src/history.rs
@@ -133,6 +133,7 @@ impl History {
         removed_count
     }
 
+    /// Remove commands between two dates (inclusive).
     pub fn remove_between_dates(&mut self, start: &NaiveDate, end: &NaiveDate) -> usize {
         let before_count = self.entries.len();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ struct Cli {
     #[arg(short, long, action = ArgAction::SetTrue, default_value = "false")]
     keep_duplicates: bool,
 
-    /// Remove commands between two dates (YYYY-MM-DD YYYY-MM-DD). The start date must be before or equal to the end date.
+    /// Remove commands between the provided two dates (included): YYYY-MM-DD YYYY-MM-DD. The first date must be before or equal to the second date.
     /// Example: --remove-between 2023-01-01 2023-06-30
     #[arg(short, long, num_args = 2, value_names = ["START_DATE", "END_DATE"], value_parser = validate_date)]
     remove_between: Option<Vec<NaiveDate>>,
@@ -97,7 +97,7 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
     }
 
     if history.size() == initial_size {
-        println!("No changes made to the history file.");
+        println!("No changes were made to the history file.");
         return Ok(None);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,15 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
     }
 
     if cli.dry_run {
-        println!("=== Dry run mode enabled. No changes will be made to the history file. ===");
+        println!(
+            "===================================================================================="
+        );
+        println!(
+            "============ Dry run mode enabled. No changes will be made to the history file. ===="
+        );
+        println!(
+            "===================================================================================="
+        );
     }
 
     let initial_size = history.size();
@@ -84,10 +92,9 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
         history.remove_duplicates();
     }
 
-    // TODO: Implement date filtering when you have the dates
-    // if let Some(dates) = cli.remove_between {
-    //     history.remove_between(&dates[0], &dates[1]);
-    // }
+    if let Some(dates) = cli.remove_between {
+        history.remove_between_dates(&dates[0], &dates[1]);
+    }
 
     if history.size() == initial_size {
         println!("No changes made to the history file.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,13 @@ impl Cli {
     /// Call this after parsing to ensure business logic constraints
     fn validate(&self) -> Result<(), String> {
         if let Some(dates) = &self.remove_between
-            && dates[0] > dates[1] {
-                return Err(format!(
-                    "Start date '{}' is after end date '{}'. Please provide valid dates.",
-                    dates[0], dates[1]
-                ));
-            }
+            && dates[0] > dates[1]
+        {
+            return Err(format!(
+                "Start date '{}' is after end date '{}'. Please provide valid dates.",
+                dates[0], dates[1]
+            ));
+        }
         Ok(())
     }
 }
@@ -71,6 +72,10 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
         return Ok(None);
     }
 
+    if cli.dry_run {
+        println!("=== Dry run mode enabled. No changes will be made to the history file. ===");
+    }
+
     let initial_size = history.size();
 
     println!("{} entries in '{}'", history.size(), history.filename());
@@ -78,8 +83,6 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
     if !cli.keep_duplicates {
         history.remove_duplicates();
     }
-
-    println!("{:?}", cli.remove_between);
 
     // TODO: Implement date filtering when you have the dates
     // if let Some(dates) = cli.remove_between {
@@ -91,12 +94,11 @@ fn run(cli: Cli) -> Result<Option<String>, String> {
         return Ok(None);
     }
 
-    if cli.dry_run {
-        println!("Dry run enabled: No changes were saved.");
-        return Ok(None);
+    if !cli.dry_run {
+        history.write(should_backup).map_err(|err| err.to_string())
+    } else {
+        Ok(None)
     }
-
-    history.write(should_backup).map_err(|err| err.to_string())
 }
 
 fn main() -> ExitCode {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,3 +1,4 @@
+use chrono::{Local, TimeZone};
 use pretty_assertions::assert_eq;
 use std::fs::File;
 use std::io::Read;
@@ -33,7 +34,7 @@ fn run_flags(flags: Vec<&str>, expected: &str) {
 }
 
 #[test]
-fn test_help() {
+fn test_cli_help() {
     run_flags(
         ["-h", "--help"].to_vec(),
         "Clean your commands history by removing duplicate commands, commands between dates, etc...",
@@ -41,7 +42,7 @@ fn test_help() {
 }
 
 #[test]
-fn test_version() {
+fn test_cli_version() {
     run_flags(
         ["-V", "--version"].to_vec(),
         format!("{} {}", PACKAGE_NAME, PACKAGE_VERSION).as_str(),
@@ -49,7 +50,7 @@ fn test_version() {
 }
 
 #[test]
-fn test_no_change_in_history() {
+fn test_cli_no_change_in_history() {
     let cmds = [
         ": 1732577005:0;tf fmt -recursive",
         ": 1732577037:0;tf apply",
@@ -84,4 +85,87 @@ fn test_no_change_in_history() {
         .expect("should read the temp file");
 
     assert_eq!(before_content, after_content);
+}
+
+#[test]
+fn test_cli_remove_between_dates() {
+    let date_2020_01_01_10h = Local.with_ymd_and_hms(2020, 1, 1, 10, 0, 0).unwrap();
+
+    let date_2020_01_01_11h = Local.with_ymd_and_hms(2020, 2, 1, 11, 0, 0).unwrap();
+
+    let date_2023_02_26_9h = Local.with_ymd_and_hms(2023, 2, 26, 9, 0, 0).unwrap();
+
+    let date_2024_03_26 = Local.with_ymd_and_hms(2024, 3, 26, 12, 0, 0).unwrap();
+
+    let date_2026_06_26 = Local.with_ymd_and_hms(2026, 6, 26, 12, 0, 0).unwrap();
+
+    let cmds = [
+        format!(": {}:0;echo 'delete me'", date_2020_01_01_10h.timestamp()),
+        format!(
+            ": {}:0;echo 'delete me too'",
+            date_2020_01_01_11h.timestamp()
+        ),
+        format!(
+            ": {}:0;echo 'delete me as well'",
+            date_2023_02_26_9h.timestamp()
+        ),
+        format!(": {}:0;echo 'keep me'", date_2024_03_26.timestamp()),
+        format!(": {}:0;echo 'keep me too'", date_2026_06_26.timestamp()),
+    ];
+
+    let tmp_file = get_tmp_file(cmds.join("\n").as_str());
+
+    let output = std::process::Command::new(BINARY_PATH)
+        .arg("--remove-between")
+        .arg(format!("{}", date_2020_01_01_10h.format("%Y-%m-%d")))
+        .arg(format!("{}", date_2023_02_26_9h.format("%Y-%m-%d")))
+        .arg("-H")
+        .arg(tmp_file.path().to_string_lossy().to_string())
+        .output()
+        .expect("executing the command should not fail");
+
+    assert!(
+        output.status.success(),
+        "the command should exit successfully but got: {:?}",
+        output
+    );
+
+    let mut after_content: String = String::new();
+    File::open(&tmp_file)
+        .expect("should open the temp file")
+        .read_to_string(&mut after_content)
+        .expect("should read the temp file");
+
+    let expected_cmds = [
+        format!(": {}:0;echo 'keep me'", date_2024_03_26.timestamp()),
+        format!(": {}:0;echo 'keep me too'", date_2026_06_26.timestamp()),
+    ]
+    .join("\n")
+        + "\n";
+
+    assert_eq!(after_content, expected_cmds);
+
+    // Now let's delete everything
+    let output = std::process::Command::new(BINARY_PATH)
+        .arg("--remove-between")
+        .arg(format!("{}", date_2024_03_26.format("%Y-%m-%d")))
+        .arg(format!("{}", date_2026_06_26.format("%Y-%m-%d")))
+        .arg("-H")
+        .arg(tmp_file.path().to_string_lossy().to_string())
+        .output()
+        .expect("executing the command should not fail");
+
+    assert!(
+        output.status.success(),
+        "the command should exit successfully but got: {:?}",
+        output
+    );
+
+    let mut after_content: String = String::new();
+    File::open(&tmp_file)
+        .expect("should open the temp file")
+        .read_to_string(&mut after_content)
+        .expect("should read the temp file");
+
+    assert_eq!(after_content, "");
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -84,7 +84,7 @@ fn test_cli_no_change_in_history() {
         .read_to_string(&mut after_content)
         .expect("should read the temp file");
 
-    assert_eq!(before_content, after_content);
+    assert_eq!(before_content, after_content, "the history file should not change");
 }
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -22,7 +22,13 @@ fn run_flags(flags: Vec<&str>, expected: &str) {
         let stdout =
             String::from_utf8(output.stdout).expect("the --help output string should be utf8");
 
-        assert!(stdout.contains(expected), "Expected to find '{}' in the output of the command '{}', but got: '{}'", expected, flag, stdout);
+        assert!(
+            stdout.contains(expected),
+            "Expected to find '{}' in the output of the command '{}', but got: '{}'",
+            expected,
+            flag,
+            stdout
+        );
     }
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -22,7 +22,7 @@ fn run_flags(flags: Vec<&str>, expected: &str) {
         let stdout =
             String::from_utf8(output.stdout).expect("the --help output string should be utf8");
 
-        assert!(stdout.contains(expected));
+        assert!(stdout.contains(expected), "Expected to find '{}' in the output of the command '{}', but got: '{}'", expected, flag, stdout);
     }
 }
 
@@ -30,7 +30,7 @@ fn run_flags(flags: Vec<&str>, expected: &str) {
 fn test_help() {
     run_flags(
         ["-h", "--help"].to_vec(),
-        "Clean your history by removing duplicate commands, commands matching regex, etc...",
+        "Clean your commands history by removing duplicate commands, commands between dates, etc...",
     );
 }
 


### PR DESCRIPTION
## Time-Based History Filtering Feature

This PR adds the ability to remove commands from your Zsh history based on time ranges, providing more granular control over history cleanup.

### 🎯 Key Feature Added

**Time Range Filtering** (`--remove-between` flag)
- Remove commands executed between two specific dates (inclusive)
- Date format: `YYYY-MM-DD`
- Example: `zhc --remove-between 2023-01-01 2023-06-30`
- Validates that start date is before or equal to end date
- Works seamlessly with existing duplicate removal functionality

### 🔧 Other Improvements

- Updated project description to reflect new capabilities
- Enhanced error messages and user feedback
- Dependency updates in `Cargo.lock`